### PR TITLE
chore: update repo URLs after rename (#5)

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -162,7 +162,7 @@ Generated with [Claude Code](https://claude.ai/code)
 
 Links use full SHA and correct repo:
 ```
-https://github.com/troylar/atlassian/blob/<full-40-char-sha>/path/to/file.py#L10-L15
+https://github.com/troylar/atlassian-mcp-servers/blob/<full-40-char-sha>/path/to/file.py#L10-L15
 ```
 
 ## Notes

--- a/bitbucket-mcp-server/pyproject.toml
+++ b/bitbucket-mcp-server/pyproject.toml
@@ -49,9 +49,9 @@ dev = [
 atlassian-bitbucket-mcp = "bitbucket_mcp_server.server:main"
 
 [project.urls]
-Homepage = "https://github.com/troylar/atlassian"
-Repository = "https://github.com/troylar/atlassian"
-Issues = "https://github.com/troylar/atlassian/issues"
+Homepage = "https://github.com/troylar/atlassian-mcp-servers"
+Repository = "https://github.com/troylar/atlassian-mcp-servers"
+Issues = "https://github.com/troylar/atlassian-mcp-servers/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/bitbucket_mcp_server"]

--- a/confluence-mcp-server/pyproject.toml
+++ b/confluence-mcp-server/pyproject.toml
@@ -49,9 +49,9 @@ dev = [
 atlassian-confluence-mcp = "confluence_mcp_server.server:main"
 
 [project.urls]
-Homepage = "https://github.com/troylar/atlassian"
-Repository = "https://github.com/troylar/atlassian"
-Issues = "https://github.com/troylar/atlassian/issues"
+Homepage = "https://github.com/troylar/atlassian-mcp-servers"
+Repository = "https://github.com/troylar/atlassian-mcp-servers"
+Issues = "https://github.com/troylar/atlassian-mcp-servers/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/confluence_mcp_server"]

--- a/jira-mcp-server/pyproject.toml
+++ b/jira-mcp-server/pyproject.toml
@@ -52,9 +52,9 @@ dev = [
 atlassian-jira-mcp = "jira_mcp_server.server:main"
 
 [project.urls]
-Homepage = "https://github.com/troylar/atlassian"
-Repository = "https://github.com/troylar/atlassian"
-Issues = "https://github.com/troylar/atlassian/issues"
+Homepage = "https://github.com/troylar/atlassian-mcp-servers"
+Repository = "https://github.com/troylar/atlassian-mcp-servers"
+Issues = "https://github.com/troylar/atlassian-mcp-servers/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/jira_mcp_server"]


### PR DESCRIPTION
## Summary

- Updated all GitHub URLs from `troylar/atlassian` to `troylar/atlassian-mcp-servers` after repo rename
- Updated pyproject.toml URLs (Homepage, Repository, Issues) for all 3 servers
- Updated code-review command link format

## Changes

- `jira-mcp-server/pyproject.toml` — updated project URLs
- `confluence-mcp-server/pyproject.toml` — updated project URLs
- `bitbucket-mcp-server/pyproject.toml` — updated project URLs
- `.claude/commands/code-review.md` — updated blob link template

## Issue References

Closes #5

## Test Plan

- [ ] No code changes — config/docs only
- [ ] URLs resolve to correct repo

---
Generated with [Claude Code](https://claude.ai/code)