### PR TITLE
fix(jira): sanitize unicode and smart quotes in text inputs (#7)

### DIFF
--- a/jira-mcp-server/src/jira_mcp_server/tools/comment_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/comment_tools.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 
 from jira_mcp_server.client import JiraClient
+from jira_mcp_server.utils.text import sanitize_text
 
 _client: Optional[JiraClient] = None
 
@@ -20,7 +21,7 @@ def jira_comment_add(issue_key: str, body: str) -> Dict[str, Any]:
     if not body or not body.strip():
         raise ValueError("Comment body cannot be empty")
     try:
-        return _client.add_comment(issue_key=issue_key, body=body)
+        return _client.add_comment(issue_key=issue_key, body=sanitize_text(body))
     except Exception as e:
         raise ValueError(f"Add comment failed: {str(e)}")
 
@@ -46,7 +47,7 @@ def jira_comment_update(issue_key: str, comment_id: str, body: str) -> Dict[str,
     if not body or not body.strip():
         raise ValueError("Comment body cannot be empty")
     try:
-        return _client.update_comment(issue_key=issue_key, comment_id=comment_id, body=body)
+        return _client.update_comment(issue_key=issue_key, comment_id=comment_id, body=sanitize_text(body))
     except Exception as e:
         raise ValueError(f"Update comment failed: {str(e)}")
 

--- a/jira-mcp-server/src/jira_mcp_server/tools/filter_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/filter_tools.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 
 from jira_mcp_server.client import JiraClient
+from jira_mcp_server.utils.text import sanitize_text
 
 _client: Optional[JiraClient] = None
 
@@ -22,7 +23,12 @@ def jira_filter_create(
     if not jql or not jql.strip():
         raise ValueError("JQL query cannot be empty")
     try:
-        return _client.create_filter(name=name, jql=jql, description=description, favourite=favourite)
+        return _client.create_filter(
+            name=sanitize_text(name),
+            jql=sanitize_text(jql),
+            description=sanitize_text(description) if description else description,
+            favourite=favourite,
+        )
     except Exception as e:
         raise ValueError(f"Filter creation failed: {str(e)}")
 
@@ -77,7 +83,11 @@ def jira_filter_update(
         raise ValueError("At least one field must be provided to update")
     try:
         return _client.update_filter(
-            filter_id=filter_id, name=name, jql=jql, description=description, favourite=favourite
+            filter_id=filter_id,
+            name=sanitize_text(name) if name else name,
+            jql=sanitize_text(jql) if jql else jql,
+            description=sanitize_text(description) if description else description,
+            favourite=favourite,
         )
     except Exception as e:
         raise ValueError(f"Filter update failed: {str(e)}")

--- a/jira-mcp-server/src/jira_mcp_server/tools/issue_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/issue_tools.py
@@ -6,6 +6,7 @@ from jira_mcp_server.client import JiraClient
 from jira_mcp_server.config import JiraConfig
 from jira_mcp_server.models import FieldSchema, FieldType, FieldValidationError
 from jira_mcp_server.schema_cache import SchemaCache
+from jira_mcp_server.utils.text import sanitize_text
 from jira_mcp_server.validators import FieldValidator
 
 _client: Optional[JiraClient] = None
@@ -95,18 +96,18 @@ def jira_issue_create(
 
     fields: Dict[str, Any] = {
         "project": {"key": project},
-        "summary": summary,
+        "summary": sanitize_text(summary),
         "issuetype": {"name": issue_type},
     }
 
     if description:
-        fields["description"] = description
+        fields["description"] = sanitize_text(description)
     if priority:
         fields["priority"] = {"name": priority}
     if assignee:
         fields["assignee"] = {"name": assignee}
     if labels:
-        fields["labels"] = labels
+        fields["labels"] = [sanitize_text(label) for label in labels]
     if due_date:
         fields["duedate"] = due_date
 
@@ -140,15 +141,15 @@ def jira_issue_update(
 
     fields: Dict[str, Any] = {}
     if summary is not None:
-        fields["summary"] = summary
+        fields["summary"] = sanitize_text(summary)
     if description is not None:
-        fields["description"] = description
+        fields["description"] = sanitize_text(description)
     if priority is not None:
         fields["priority"] = {"name": priority}
     if assignee is not None:
         fields["assignee"] = {"name": assignee}
     if labels is not None:
-        fields["labels"] = labels
+        fields["labels"] = [sanitize_text(label) for label in labels]
     if due_date is not None:
         fields["duedate"] = due_date
 

--- a/jira-mcp-server/src/jira_mcp_server/tools/search_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/search_tools.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 from jira_mcp_server.client import JiraClient
+from jira_mcp_server.utils.text import escape_jql_value, sanitize_text
 
 _client: Optional[JiraClient] = None
 
@@ -25,27 +26,27 @@ def build_jql_from_criteria(
 ) -> str:
     clauses: List[str] = []
     if project:
-        clauses.append(f"project = {project}")
+        clauses.append(f"project = {escape_jql_value(project)}")
     if assignee:
         if assignee == "currentUser()":
             clauses.append("assignee = currentUser()")
         else:
-            clauses.append(f"assignee = {assignee}")
+            clauses.append(f"assignee = {escape_jql_value(assignee)}")
     if status:
-        clauses.append(f'status = "{status}"')
+        clauses.append(f"status = {escape_jql_value(status)}")
     if priority:
-        clauses.append(f'priority = "{priority}"')
+        clauses.append(f"priority = {escape_jql_value(priority)}")
     if labels:
         for label in labels:
-            clauses.append(f'labels = "{label}"')
+            clauses.append(f"labels = {escape_jql_value(label)}")
     if created_after:
-        clauses.append(f'created >= "{created_after}"')
+        clauses.append(f"created >= {escape_jql_value(created_after)}")
     if created_before:
-        clauses.append(f'created <= "{created_before}"')
+        clauses.append(f"created <= {escape_jql_value(created_before)}")
     if updated_after:
-        clauses.append(f'updated >= "{updated_after}"')
+        clauses.append(f"updated >= {escape_jql_value(updated_after)}")
     if updated_before:
-        clauses.append(f'updated <= "{updated_before}"')
+        clauses.append(f"updated <= {escape_jql_value(updated_before)}")
     return " AND ".join(clauses) if clauses else ""
 
 
@@ -93,6 +94,6 @@ def jira_search_jql(
     if not jql or not jql.strip():
         raise ValueError("JQL query cannot be empty")
     try:
-        return _client.search_issues(jql=jql, max_results=max_results, start_at=start_at)
+        return _client.search_issues(jql=sanitize_text(jql), max_results=max_results, start_at=start_at)
     except Exception as e:
         raise ValueError(f"JQL search failed: {str(e)}")

--- a/jira-mcp-server/src/jira_mcp_server/tools/user_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/user_tools.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List, Optional
 
 from jira_mcp_server.client import JiraClient
+from jira_mcp_server.utils.text import sanitize_text
 
 _client: Optional[JiraClient] = None
 
@@ -18,7 +19,7 @@ def jira_user_search(query: str, max_results: int = 50) -> List[Dict[str, Any]]:
     if not query or not query.strip():
         raise ValueError("Search query cannot be empty")
     try:
-        return _client.search_users(query, max_results=max_results)
+        return _client.search_users(sanitize_text(query), max_results=max_results)
     except Exception as e:
         raise ValueError(f"User search failed: {str(e)}")
 

--- a/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
+++ b/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for Jira MCP Server."""
+
+from jira_mcp_server.utils.text import escape_jql_value, sanitize_text
+
+__all__ = ["sanitize_text", "escape_jql_value"]

--- a/jira-mcp-server/src/jira_mcp_server/utils/text.py
+++ b/jira-mcp-server/src/jira_mcp_server/utils/text.py
@@ -1,0 +1,37 @@
+"""Text sanitization utilities for Jira API compatibility."""
+
+import unicodedata
+
+SMART_CHAR_MAP = str.maketrans(
+    {
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2026": "...",
+    }
+)
+
+
+def sanitize_text(text: str) -> str:
+    """Normalize unicode and replace smart quotes/dashes with ASCII equivalents.
+
+    MCP clients often send smart/curly quotes and other unicode characters
+    that Jira's REST API rejects. This function normalizes text to prevent
+    'disallowed characters' errors.
+    """
+    text = unicodedata.normalize("NFC", text)
+    return text.translate(SMART_CHAR_MAP)
+
+
+def escape_jql_value(value: str) -> str:
+    """Sanitize and escape a value for safe interpolation into a JQL query.
+
+    Returns the value wrapped in double quotes with internal quotes and
+    backslashes escaped. The caller should NOT add surrounding quotes.
+    """
+    value = sanitize_text(value)
+    value = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{value}"'

--- a/jira-mcp-server/tests/unit/test_text.py
+++ b/jira-mcp-server/tests/unit/test_text.py
@@ -1,0 +1,95 @@
+"""Tests for text sanitization utilities."""
+
+from jira_mcp_server.utils.text import escape_jql_value, sanitize_text
+
+
+class TestSanitizeText:
+    def test_passthrough_clean_ascii(self) -> None:
+        assert sanitize_text("hello world") == "hello world"
+
+    def test_passthrough_empty_string(self) -> None:
+        assert sanitize_text("") == ""
+
+    def test_left_double_smart_quote(self) -> None:
+        assert sanitize_text("\u201chello\u201d") == '"hello"'
+
+    def test_right_double_smart_quote(self) -> None:
+        assert sanitize_text("say \u201cyes\u201d") == 'say "yes"'
+
+    def test_left_single_smart_quote(self) -> None:
+        assert sanitize_text("\u2018hi\u2019") == "'hi'"
+
+    def test_right_single_smart_quote(self) -> None:
+        assert sanitize_text("it\u2019s fine") == "it's fine"
+
+    def test_em_dash(self) -> None:
+        assert sanitize_text("foo\u2014bar") == "foo-bar"
+
+    def test_en_dash(self) -> None:
+        assert sanitize_text("foo\u2013bar") == "foo-bar"
+
+    def test_ellipsis(self) -> None:
+        assert sanitize_text("wait\u2026") == "wait..."
+
+    def test_mixed_smart_chars(self) -> None:
+        text = "\u201cHello\u201d \u2014 it\u2019s a \u2018test\u2019\u2026"
+        expected = '"Hello" - it\'s a \'test\'...'
+        assert sanitize_text(text) == expected
+
+    def test_nfc_normalization(self) -> None:
+        # e + combining acute accent (NFD) should normalize to single char (NFC)
+        nfd = "e\u0301"
+        result = sanitize_text(nfd)
+        assert result == "\u00e9"
+        assert len(result) == 1
+
+    def test_preserves_regular_unicode(self) -> None:
+        assert sanitize_text("caf\u00e9") == "caf\u00e9"
+
+    def test_preserves_newlines_and_whitespace(self) -> None:
+        assert sanitize_text("line1\nline2\ttab") == "line1\nline2\ttab"
+
+    def test_jql_with_smart_quotes(self) -> None:
+        jql = 'assignee = f12345 AND resolution = \u201cUnresolved\u201d'
+        expected = 'assignee = f12345 AND resolution = "Unresolved"'
+        assert sanitize_text(jql) == expected
+
+
+class TestEscapeJqlValue:
+    def test_simple_value(self) -> None:
+        assert escape_jql_value("In Progress") == '"In Progress"'
+
+    def test_empty_value(self) -> None:
+        assert escape_jql_value("") == '""'
+
+    def test_value_with_double_quote(self) -> None:
+        assert escape_jql_value('say "hello"') == '"say \\"hello\\""'
+
+    def test_value_with_backslash(self) -> None:
+        assert escape_jql_value("path\\to") == '"path\\\\to"'
+
+    def test_value_with_backslash_and_quote(self) -> None:
+        assert escape_jql_value('a\\"b') == '"a\\\\\\"b"'
+
+    def test_smart_quotes_replaced_then_escaped(self) -> None:
+        # Smart quotes become straight quotes, then get escaped
+        assert escape_jql_value("\u201chello\u201d") == '"\\"hello\\""'
+
+    def test_em_dash_replaced(self) -> None:
+        assert escape_jql_value("foo\u2014bar") == '"foo-bar"'
+
+    def test_nfc_normalization(self) -> None:
+        result = escape_jql_value("e\u0301")
+        assert result == '"\u00e9"'
+
+    def test_passthrough_clean_value(self) -> None:
+        assert escape_jql_value("bug") == '"bug"'
+
+    def test_label_with_special_chars(self) -> None:
+        assert escape_jql_value("feature-docs") == '"feature-docs"'
+
+    def test_injection_attempt_with_quote(self) -> None:
+        # Attempting JQL injection via a label containing "
+        malicious = 'bug" OR priority = "High'
+        result = escape_jql_value(malicious)
+        assert result == '"bug\\" OR priority = \\"High"'

--- a/jira-mcp-server/tests/unit/test_tools.py
+++ b/jira-mcp-server/tests/unit/test_tools.py
@@ -435,12 +435,12 @@ class TestBuildJql:
     def test_project_only(self) -> None:
         from jira_mcp_server.tools.search_tools import build_jql_from_criteria
 
-        assert build_jql_from_criteria(project="TEST") == "project = TEST"
+        assert build_jql_from_criteria(project="TEST") == 'project = "TEST"'
 
     def test_assignee(self) -> None:
         from jira_mcp_server.tools.search_tools import build_jql_from_criteria
 
-        assert build_jql_from_criteria(assignee="john") == "assignee = john"
+        assert build_jql_from_criteria(assignee="john") == 'assignee = "john"'
 
     def test_assignee_current_user(self) -> None:
         from jira_mcp_server.tools.search_tools import build_jql_from_criteria


### PR DESCRIPTION
## Summary

- Add `sanitize_text()` utility that NFC-normalizes unicode and replaces smart/curly quotes, em/en dashes, and ellipsis with ASCII equivalents
- Add `escape_jql_value()` utility that sanitizes and properly escapes values for safe JQL interpolation (prevents injection)
- Apply sanitization at the tool layer across all 5 tool modules that accept user text (search, issue, comment, filter, user)
- Fix `build_jql_from_criteria()` to use proper value escaping instead of raw string interpolation

## Changes

### `jira-mcp-server`
- `src/jira_mcp_server/utils/text.py` — new module with `sanitize_text()` and `escape_jql_value()`
- `src/jira_mcp_server/utils/__init__.py` — new package with re-exports
- `src/jira_mcp_server/tools/search_tools.py` — escape all 9 JQL interpolation points; sanitize raw JQL input
- `src/jira_mcp_server/tools/issue_tools.py` — sanitize summary, description, labels in create and update
- `src/jira_mcp_server/tools/comment_tools.py` — sanitize comment body in add and update
- `src/jira_mcp_server/tools/filter_tools.py` — sanitize filter name, JQL, description in create and update
- `src/jira_mcp_server/tools/user_tools.py` — sanitize search query
- `tests/unit/test_text.py` — 25 new tests for sanitization helpers
- `tests/unit/test_tools.py` — updated JQL assertions for new quoting format

## Issue References

Closes #7

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (447 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] Type check passes: `cd jira-mcp-server && mypy src/`
- [x] 100% coverage maintained
- [x] Smart quotes → straight quotes (14 test cases)
- [x] JQL injection via label with embedded quotes (test case)
- [x] NFC unicode normalization (combining characters)
- [x] Passthrough of clean ASCII text (no false positives)
- [x] Security scan: no hardcoded credentials, proper escape ordering

---
Generated with [Claude Code](https://claude.ai/code)