### PR TITLE
fix(jira): convert markdown backticks to Jira wiki markup (#9)

### DIFF
--- a/jira-mcp-server/tests/unit/test_text.py
+++ b/jira-mcp-server/tests/unit/test_text.py
@@ -54,6 +54,31 @@ class TestSanitizeText:
         expected = 'assignee = f12345 AND resolution = "Unresolved"'
         assert sanitize_text(jql) == expected
 
+    def test_inline_code_backticks(self) -> None:
+        assert sanitize_text("use `foo` here") == "use {{foo}} here"
+
+    def test_multiple_inline_code(self) -> None:
+        assert sanitize_text("`a` and `b`") == "{{a}} and {{b}}"
+
+    def test_stray_backtick_removed(self) -> None:
+        assert sanitize_text("it`s broken") == "its broken"
+
+    def test_backtick_at_start_and_end(self) -> None:
+        assert sanitize_text("`code`") == "{{code}}"
+
+    def test_mixed_backticks_and_smart_quotes(self) -> None:
+        text = "\u201cuse `cmd` here\u201d"
+        assert sanitize_text(text) == '"use {{cmd}} here"'
+
+    def test_triple_backtick_stripped(self) -> None:
+        assert sanitize_text("```hello```") == "{{hello}}"
+
+    def test_empty_backticks_stripped(self) -> None:
+        assert sanitize_text("``") == ""
+
+    def test_no_backticks_passthrough(self) -> None:
+        assert sanitize_text("no backticks here") == "no backticks here"
+
 
 class TestEscapeJqlValue:
     def test_simple_value(self) -> None:


### PR DESCRIPTION
## Summary

- Convert markdown inline code (`` `text` ``) to Jira wiki markup (`{{text}}`) in `sanitize_text()`
- Strip remaining stray backticks that Jira rejects as "disallowed characters"
- 8 new test cases covering inline code, multiple backticks, triple backticks, mixed with smart quotes

## Changes

### `jira-mcp-server`
- `src/jira_mcp_server/utils/text.py` — add regex for inline code conversion + backtick stripping
- `tests/unit/test_text.py` — 8 new tests

## Issue References

Closes #9

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (455 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] 100% coverage maintained

---
Generated with [Claude Code](https://claude.ai/code)