### PR TITLE
fix(jira): convert markdown formatting to Jira wiki markup (#11)

### DIFF
--- a/jira-mcp-server/src/jira_mcp_server/tools/comment_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/comment_tools.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, Optional
 
 from jira_mcp_server.client import JiraClient
-from jira_mcp_server.utils.text import sanitize_text
+from jira_mcp_server.utils.text import sanitize_long_text
 
 _client: Optional[JiraClient] = None
 
@@ -21,7 +21,7 @@ def jira_comment_add(issue_key: str, body: str) -> Dict[str, Any]:
     if not body or not body.strip():
         raise ValueError("Comment body cannot be empty")
     try:
-        return _client.add_comment(issue_key=issue_key, body=sanitize_text(body))
+        return _client.add_comment(issue_key=issue_key, body=sanitize_long_text(body))
     except Exception as e:
         raise ValueError(f"Add comment failed: {str(e)}")
 
@@ -47,7 +47,7 @@ def jira_comment_update(issue_key: str, comment_id: str, body: str) -> Dict[str,
     if not body or not body.strip():
         raise ValueError("Comment body cannot be empty")
     try:
-        return _client.update_comment(issue_key=issue_key, comment_id=comment_id, body=sanitize_text(body))
+        return _client.update_comment(issue_key=issue_key, comment_id=comment_id, body=sanitize_long_text(body))
     except Exception as e:
         raise ValueError(f"Update comment failed: {str(e)}")
 

--- a/jira-mcp-server/src/jira_mcp_server/tools/issue_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/issue_tools.py
@@ -6,7 +6,7 @@ from jira_mcp_server.client import JiraClient
 from jira_mcp_server.config import JiraConfig
 from jira_mcp_server.models import FieldSchema, FieldType, FieldValidationError
 from jira_mcp_server.schema_cache import SchemaCache
-from jira_mcp_server.utils.text import sanitize_text
+from jira_mcp_server.utils.text import sanitize_long_text, sanitize_text
 from jira_mcp_server.validators import FieldValidator
 
 _client: Optional[JiraClient] = None
@@ -101,7 +101,7 @@ def jira_issue_create(
     }
 
     if description:
-        fields["description"] = sanitize_text(description)
+        fields["description"] = sanitize_long_text(description)
     if priority:
         fields["priority"] = {"name": priority}
     if assignee:
@@ -143,7 +143,7 @@ def jira_issue_update(
     if summary is not None:
         fields["summary"] = sanitize_text(summary)
     if description is not None:
-        fields["description"] = sanitize_text(description)
+        fields["description"] = sanitize_long_text(description)
     if priority is not None:
         fields["priority"] = {"name": priority}
     if assignee is not None:

--- a/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
+++ b/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility functions for Jira MCP Server."""
 
-from jira_mcp_server.utils.text import escape_jql_value, sanitize_text
+from jira_mcp_server.utils.text import escape_jql_value, sanitize_long_text, sanitize_text
 
-__all__ = ["sanitize_text", "escape_jql_value"]
+__all__ = ["sanitize_text", "sanitize_long_text", "escape_jql_value"]

--- a/jira-mcp-server/src/jira_mcp_server/utils/text.py
+++ b/jira-mcp-server/src/jira_mcp_server/utils/text.py
@@ -17,6 +17,28 @@ SMART_CHAR_MAP = str.maketrans(
 
 _INLINE_CODE_RE = re.compile(r"`([^`]+)`")
 
+_MD_FENCED_CODE_RE = re.compile(r"^```(\w*)\n(.*?)^```", re.MULTILINE | re.DOTALL)
+_MD_HEADING_RE = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+_MD_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_MD_ITALIC_STAR_RE = re.compile(r"(?<!\*)\*(?!\*|\s)(.+?)(?<!\*|\s)\*(?!\*)")
+_MD_STRIKETHROUGH_RE = re.compile(r"~~(.+?)~~")
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_MD_BULLET_RE = re.compile(r"^[-*]\s+", re.MULTILINE)
+_MD_NUMBERED_RE = re.compile(r"^\d+\.\s+", re.MULTILINE)
+_MD_HR_RE = re.compile(r"^[-*]{3,}\s*$", re.MULTILINE)
+
+_JIRA_BRACE_PATTERN_RE = re.compile(
+    r"\{\{.+?\}\}"  # {{inline code}}
+    r"|\{code(?::\w+)?\}.*?\{code\}"  # {code}...{code} or {code:lang}...{code}
+    r"|\{quote\}.*?\{quote\}"  # {quote}...{quote}
+    r"|\{noformat\}.*?\{noformat\}",  # {noformat}...{noformat}
+    re.DOTALL,
+)
+
+_CODE_PLACEHOLDER = "\x00CODE_BLOCK_{}\x00"
+_BOLD_PLACEHOLDER = "\x00BOLD_{}\x00"
+
 
 def sanitize_text(text: str) -> str:
     """Normalize unicode and replace smart quotes/dashes with ASCII equivalents.
@@ -32,6 +54,119 @@ def sanitize_text(text: str) -> str:
     text = text.translate(SMART_CHAR_MAP)
     text = _INLINE_CODE_RE.sub(r"{{\1}}", text)
     text = text.replace("`", "")
+    return text
+
+
+def _replace_fenced_code(match: re.Match[str]) -> str:
+    lang = match.group(1)
+    code = match.group(2)
+    if code.endswith("\n"):
+        code = code[:-1]
+    if lang:
+        return f"{{code:{lang}}}\n{code}\n{{code}}"
+    return f"{{code}}\n{code}\n{{code}}"
+
+
+def _replace_heading(match: re.Match[str]) -> str:
+    level = len(match.group(1))
+    text = match.group(2)
+    return f"h{level}. {text}"
+
+
+def _escape_lone_braces(text: str) -> str:
+    """Strip { and } that are not part of Jira macros or inline code markup.
+
+    Preserves {{inline}}, {code}...{code}, {code:lang}...{code},
+    {quote}...{quote}, and {noformat}...{noformat} patterns.
+    Strips all other lone braces.
+    """
+    protected: list[tuple[int, int]] = []
+    for match in _JIRA_BRACE_PATTERN_RE.finditer(text):
+        protected.append((match.start(), match.end()))
+
+    result: list[str] = []
+    i = 0
+    for start, end in protected:
+        for j in range(i, start):
+            ch = text[j]
+            if ch not in "{}":
+                result.append(ch)
+        result.append(text[start:end])
+        i = end
+    for j in range(i, len(text)):
+        ch = text[j]
+        if ch not in "{}":
+            result.append(ch)
+    return "".join(result)
+
+
+def markdown_to_jira(text: str) -> str:
+    """Convert markdown formatting to Jira wiki markup.
+
+    Handles headings, bold, italic, strikethrough, links, images,
+    bullet lists, numbered lists, fenced code blocks, and horizontal rules.
+
+    Lone curly braces that would trigger Jira macro parsing are stripped.
+    """
+    if not text:
+        return text
+
+    code_blocks: list[str] = []
+
+    def _extract_code(match: re.Match[str]) -> str:
+        replacement = _replace_fenced_code(match)
+        idx = len(code_blocks)
+        code_blocks.append(replacement)
+        return _CODE_PLACEHOLDER.format(idx)
+
+    text = _MD_FENCED_CODE_RE.sub(_extract_code, text)
+
+    text = _MD_HEADING_RE.sub(_replace_heading, text)
+
+    bold_parts: list[str] = []
+
+    def _extract_bold(match: re.Match[str]) -> str:
+        jira_bold = f"*{match.group(1)}*"
+        idx = len(bold_parts)
+        bold_parts.append(jira_bold)
+        return _BOLD_PLACEHOLDER.format(idx)
+
+    text = _MD_BOLD_RE.sub(_extract_bold, text)
+
+    text = _MD_ITALIC_STAR_RE.sub(r"_\1_", text)
+
+    for idx, val in enumerate(bold_parts):
+        text = text.replace(_BOLD_PLACEHOLDER.format(idx), val)
+
+    text = _MD_STRIKETHROUGH_RE.sub(r"-\1-", text)
+
+    text = _MD_IMAGE_RE.sub(r"!\2!", text)
+    text = _MD_LINK_RE.sub(r"[\1|\2]", text)
+
+    text = _MD_BULLET_RE.sub("* ", text)
+    text = _MD_NUMBERED_RE.sub("# ", text)
+
+    text = _MD_HR_RE.sub("----", text)
+
+    text = _escape_lone_braces(text)
+
+    for idx, block in enumerate(code_blocks):
+        text = text.replace(_CODE_PLACEHOLDER.format(idx), block)
+
+    return text
+
+
+def sanitize_long_text(text: str) -> str:
+    """Sanitize long-form text fields (descriptions, comments).
+
+    Chains sanitize_text (unicode normalization, smart quotes, inline code)
+    with markdown_to_jira (full markdown-to-wiki-markup conversion).
+
+    Use this for description and comment body fields. Use sanitize_text()
+    for short fields like summary, labels, and filter names.
+    """
+    text = sanitize_text(text)
+    text = markdown_to_jira(text)
     return text
 
 


### PR DESCRIPTION
## Summary

- Add `markdown_to_jira()` converter that transforms markdown formatting to Jira wiki markup
- Add `sanitize_long_text()` that chains unicode normalization with markdown conversion
- Apply to description and comment body fields only (not summary, labels, or JQL)
- 53 new tests (508 total), 100% coverage maintained

## Changes

### jira-mcp-server
- `src/jira_mcp_server/utils/text.py` — added `markdown_to_jira()` with code block protection, bold/italic placeholder system, brace escaping; added `sanitize_long_text()` chaining function
- `src/jira_mcp_server/utils/__init__.py` — exported new functions
- `src/jira_mcp_server/tools/issue_tools.py` — description field uses `sanitize_long_text` instead of `sanitize_text`
- `src/jira_mcp_server/tools/comment_tools.py` — body field uses `sanitize_long_text` instead of `sanitize_text`
- `tests/unit/test_text.py` — `TestMarkdownToJira` (42 tests) and `TestSanitizeLongText` (6 tests)
- `tests/unit/test_tools.py` — 4 new tests verifying tool-layer sanitization contract

### Conversion Rules
| Markdown | Jira Wiki |
|----------|-----------|
| `# Heading` | `h1. Heading` |
| `**bold**` | `*bold*` |
| `*italic*` | `_italic_` |
| `~~strike~~` | `-strike-` |
| `[text](url)` | `[text\|url]` |
| `![alt](url)` | `!url!` |
| `- bullet` | `* bullet` |
| `1. item` | `# item` |
| ` ```code``` ` | `{code}...{code}` |
| `---` | `----` |
| lone `{` `}` | stripped |

## Issue References

Closes #11

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (508 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] Type check passes: `cd jira-mcp-server && mypy src/`
- [x] 100% coverage maintained
- [x] Code blocks content preserved (not converted)
- [x] Bold/italic don't collide (placeholder system)
- [x] Tool-layer tests verify sanitization is applied

---
Generated with [Claude Code](https://claude.ai/code)