### PR TITLE
fix(jira): strip invisible Unicode chars and add diagnostic hints (#14)

### DIFF
--- a/jira-mcp-server/tests/unit/test_text.py
+++ b/jira-mcp-server/tests/unit/test_text.py
@@ -78,6 +78,59 @@ class TestSanitizeText:
     def test_no_backticks_passthrough(self) -> None:
         assert sanitize_text("no backticks here") == "no backticks here"
 
+    def test_strip_zero_width_space(self) -> None:
+        assert sanitize_text("hello\u200bworld") == "helloworld"
+
+    def test_strip_zero_width_non_joiner(self) -> None:
+        assert sanitize_text("hello\u200cworld") == "helloworld"
+
+    def test_strip_zero_width_joiner(self) -> None:
+        assert sanitize_text("hello\u200dworld") == "helloworld"
+
+    def test_strip_left_to_right_mark(self) -> None:
+        assert sanitize_text("hello\u200eworld") == "helloworld"
+
+    def test_strip_right_to_left_mark(self) -> None:
+        assert sanitize_text("hello\u200fworld") == "helloworld"
+
+    def test_strip_byte_order_mark(self) -> None:
+        assert sanitize_text("\ufeffhello") == "hello"
+
+    def test_strip_word_joiner(self) -> None:
+        assert sanitize_text("hello\u2060world") == "helloworld"
+
+    def test_non_breaking_space_to_space(self) -> None:
+        assert sanitize_text("hello\u00a0world") == "hello world"
+
+    def test_strip_null_byte(self) -> None:
+        assert sanitize_text("hello\x00world") == "helloworld"
+
+    def test_strip_bell_char(self) -> None:
+        assert sanitize_text("hello\x07world") == "helloworld"
+
+    def test_strip_form_feed(self) -> None:
+        assert sanitize_text("hello\x0cworld") == "helloworld"
+
+    def test_preserve_newline(self) -> None:
+        assert sanitize_text("line1\nline2") == "line1\nline2"
+
+    def test_preserve_tab(self) -> None:
+        assert sanitize_text("col1\tcol2") == "col1\tcol2"
+
+    def test_preserve_carriage_return(self) -> None:
+        assert sanitize_text("line1\r\nline2") == "line1\r\nline2"
+
+    def test_strip_soft_hyphen(self) -> None:
+        assert sanitize_text("auto\u00admatic") == "automatic"
+
+    def test_mixed_invisible_and_smart_chars(self) -> None:
+        text = "\ufeff\u201chello\u200b world\u201d"
+        assert sanitize_text(text) == '"hello world"'
+
+    def test_strip_multiple_invisible_chars(self) -> None:
+        text = "\u200b\u200c\u200d\u200e\u200f\ufeff\u2060"
+        assert sanitize_text(text) == ""
+
 
 class TestMarkdownToJira:
     def test_passthrough_plain_text(self) -> None:


### PR DESCRIPTION
## Summary

- Strip invisible Unicode characters (zero-width spaces, BOM, directional marks, control chars) in `sanitize_text()` — these cause Jira's "disallowed characters" errors
- Replace non-breaking space (U+00A0) with regular space
- Add diagnostic hints when Jira reports "disallowed characters" — lists the non-ASCII codepoints found in the request body
- 25 new tests (530 total), 100% coverage

## Changes

### jira-mcp-server
- `src/jira_mcp_server/utils/text.py` — added `_strip_invisible_chars()`, non-breaking space to SMART_CHAR_MAP, `_ALLOWED_CONTROL_CHARS` set
- `src/jira_mcp_server/client.py` — added `_disallowed_char_hint()` method, enhanced 400 error handler to include hints
- `tests/unit/test_text.py` — 17 new tests for invisible char stripping
- `tests/unit/test_client.py` — 5 new tests for diagnostic hints

## Issue References

Closes #14

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (530 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] 100% coverage maintained

---
Generated with [Claude Code](https://claude.ai/code)