### PR TITLE
fix(jira): use XML 1.0 char validation and sanitize all text fields (#16)

### DIFF
--- a/jira-mcp-server/src/jira_mcp_server/tools/workflow_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/workflow_tools.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, Optional
 
 from jira_mcp_server.client import JiraClient
+from jira_mcp_server.utils.text import sanitize_value
 
 _client: Optional[JiraClient] = None
 
@@ -47,7 +48,8 @@ def jira_workflow_transition(
     if not transition_id or not transition_id.strip():
         raise ValueError("Transition ID cannot be empty")
     try:
-        _client.transition_issue(issue_key=issue_key, transition_id=transition_id, fields=fields)
+        sanitized_fields = sanitize_value(fields) if fields else fields
+        _client.transition_issue(issue_key=issue_key, transition_id=transition_id, fields=sanitized_fields)
         return {
             "success": True,
             "message": f"Issue {issue_key} transitioned successfully",

--- a/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
+++ b/jira-mcp-server/src/jira_mcp_server/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility functions for Jira MCP Server."""
 
-from jira_mcp_server.utils.text import escape_jql_value, sanitize_long_text, sanitize_text
+from jira_mcp_server.utils.text import escape_jql_value, sanitize_long_text, sanitize_text, sanitize_value
 
-__all__ = ["sanitize_text", "sanitize_long_text", "escape_jql_value"]
+__all__ = ["sanitize_text", "sanitize_long_text", "sanitize_value", "escape_jql_value"]


### PR DESCRIPTION
## Summary

- Replace Unicode category-based filtering with XML 1.0 valid character ranges plus Cc/Cf/Co stripping — this is the definitive set of characters Jira (Java/XML) accepts
- Fix `sanitize_long_text()` ordering bug where backticks were stripped before fenced code blocks could be extracted — ```` ```python ``` ```` now correctly converts to `{code:python}...{code}`
- Add `sanitize_value()` recursive helper for dict/list/string sanitization
- Sanitize ALL remaining unsanitized text fields: priority, assignee, due_date, link_type, custom fields, workflow transition fields

## Changes

### jira-mcp-server
- `src/jira_mcp_server/utils/text.py` — `_is_xml_valid()` + `_strip_disallowed_chars()` replace `_strip_invisible_chars()`, `sanitize_long_text()` reordered, `sanitize_value()` added
- `src/jira_mcp_server/tools/issue_tools.py` — priority, assignee, due_date, custom_fields, link_type now sanitized
- `src/jira_mcp_server/tools/workflow_tools.py` — transition fields now sanitized
- `tests/unit/test_text.py` — 24 new tests (XML validation, Private Use Area, supplementary planes, sanitize_value, fenced code blocks in long text)

## Issue References

Closes #16

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (554 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] Type check: `cd jira-mcp-server && mypy src/`
- [x] 100% coverage maintained

---
Generated with [Claude Code](https://claude.ai/code)