### PR TITLE
feat(confluence): add macro rendering tool (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A monorepo of [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) s
 | Server | Tools | Package |
 |--------|-------|---------|
 | [Jira](jira-mcp-server/) | 37 | `atlassian-jira-mcp` |
-| [Confluence](confluence-mcp-server/) | 38 | `atlassian-confluence-mcp` |
+| [Confluence](confluence-mcp-server/) | 39 | `atlassian-confluence-mcp` |
 | [Bitbucket](bitbucket-mcp-server/) | 44 | `atlassian-bitbucket-mcp` |
 
 ## Structure

--- a/confluence-mcp-server/src/confluence_mcp_server/server.py
+++ b/confluence-mcp-server/src/confluence_mcp_server/server.py
@@ -519,6 +519,39 @@ def confluence_permissions_set(
     return _get_client().set_page_permissions(page_id, restrictions)  # pragma: no cover
 
 
+# --- Macro Tools (1 tool) ---
+
+
+@mcp.tool()
+def confluence_macro_render(
+    macro_name: str,
+    parameters: Dict[str, str] | None = None,
+    body: str | None = None,
+    body_type: str = "rich-text-body",
+) -> Dict[str, Any]:  # pragma: no cover
+    """Render a Confluence macro as storage-format XHTML.
+
+    Returns XHTML that can be embedded in page body content. Works with any
+    macro name — built-in (code, toc, panel) or third-party plugins.
+
+    Args:
+        macro_name: Macro identifier (e.g., "code", "toc", "panel", "info",
+                    "warning", "expand", "note", "excerpt", or any plugin macro)
+        parameters: Optional macro parameters as key-value pairs
+        body: Optional macro body content
+        body_type: Body wrapping — "plain-text-body" for code/noformat (CDATA),
+                   "rich-text-body" for panel/expand/info (XHTML). Default: "rich-text-body"
+
+    Examples:
+        Table of contents: macro_name="toc"
+        Code block: macro_name="code", parameters={"language": "python"},
+            body="print('hello')", body_type="plain-text-body"
+        Info panel: macro_name="info", parameters={"title": "Note"}, body="<p>Important info</p>"
+        Expand section: macro_name="expand", parameters={"title": "Details"}, body="<p>Hidden content</p>"
+    """
+    return _get_client().render_macro(macro_name, parameters, body, body_type)  # pragma: no cover
+
+
 def main() -> None:
     """Main entry point for the Confluence MCP server."""
     try:


### PR DESCRIPTION
## Summary

- Add `confluence_macro_render` tool that generates Confluence storage-format XHTML for any macro (built-in or third-party plugin)
- Pure string generation — no API calls, works offline
- Supports `plain-text-body` (CDATA-wrapped, for code/noformat) and `rich-text-body` (XHTML, for panel/expand/info)
- Input validation: macro name regex allowlist, body type allowlist, XML/CDATA escaping

## Changes

### Confluence MCP Server
- `src/confluence_mcp_server/client.py` — added `render_macro()` method with XHTML generation, CDATA `]]>` escaping, XML entity escaping, and input validation
- `src/confluence_mcp_server/server.py` — added `confluence_macro_render` tool (39th tool)
- `tests/unit/test_client.py` — added 21 tests in `TestRenderMacro` class

### Root
- `README.md` — updated Confluence tool count from 38 to 39

## Issue References

Closes #18

## Test Plan

- [x] Tests pass: `cd confluence-mcp-server && pytest` (182 passed)
- [x] Lint passes: `cd confluence-mcp-server && ruff check src/ tests/`
- [x] Type check passes: `cd confluence-mcp-server && mypy src/`
- [x] 100% coverage maintained (471 statements, 0 missed)
- [x] CDATA `]]>` injection properly escaped
- [x] XML special characters escaped in parameter keys/values
- [x] Validation rejects empty/invalid macro names and invalid body types
- [x] Works with custom/plugin macro names

---
Generated with [Claude Code](https://claude.ai/code)