### PR TITLE
feat(bitbucket): add PR reviewer assignment tools

### DIFF
--- a/bitbucket-mcp-server/src/bitbucket_mcp_server/server.py
+++ b/bitbucket-mcp-server/src/bitbucket_mcp_server/server.py
@@ -257,7 +257,13 @@ def bitbucket_pr_get(project: str, repo: str, pr_id: int) -> Dict[str, Any]:  # 
 
 @mcp.tool()
 def bitbucket_pr_create(
-    project: str, repo: str, title: str, source_branch: str, target_branch: str, description: str = ""
+    project: str,
+    repo: str,
+    title: str,
+    source_branch: str,
+    target_branch: str,
+    description: str = "",
+    reviewers: List[str] | None = None,
 ) -> Dict[str, Any]:  # pragma: no cover
     """Create a pull request.
 
@@ -268,8 +274,11 @@ def bitbucket_pr_create(
         source_branch: Source branch name
         target_branch: Target branch name
         description: Optional PR description
+        reviewers: Optional list of reviewer usernames (UUIDs for Cloud, usernames for DC)
     """
-    return _get_client().create_pr(project, repo, title, source_branch, target_branch, description)  # pragma: no cover
+    return _get_client().create_pr(  # pragma: no cover
+        project, repo, title, source_branch, target_branch, description, reviewers
+    )
 
 
 @mcp.tool()
@@ -464,6 +473,49 @@ def bitbucket_pr_needs_work(project: str, repo: str, pr_id: int) -> Dict[str, An
         pr_id: PR ID
     """
     return _get_client().needs_work_pr(project, repo, pr_id)  # pragma: no cover
+
+
+# --- PR Reviewer Tools (3 tools) ---
+
+
+@mcp.tool()
+def bitbucket_pr_reviewer_list(project: str, repo: str, pr_id: int) -> Dict[str, Any]:  # pragma: no cover
+    """List reviewers on a pull request.
+
+    Args:
+        project: Project key
+        repo: Repository slug
+        pr_id: PR ID
+    """
+    return _get_client().get_pr_reviewers(project, repo, pr_id)  # pragma: no cover
+
+
+@mcp.tool()
+def bitbucket_pr_reviewer_add(project: str, repo: str, pr_id: int, username: str) -> Dict[str, Any]:  # pragma: no cover
+    """Add a reviewer to a pull request.
+
+    Args:
+        project: Project key
+        repo: Repository slug
+        pr_id: PR ID
+        username: Reviewer username (UUID for Cloud, username for Data Center)
+    """
+    return _get_client().add_pr_reviewer(project, repo, pr_id, username)  # pragma: no cover
+
+
+@mcp.tool()
+def bitbucket_pr_reviewer_remove(  # pragma: no cover
+    project: str, repo: str, pr_id: int, username: str
+) -> Dict[str, Any]:  # pragma: no cover
+    """Remove a reviewer from a pull request.
+
+    Args:
+        project: Project key
+        repo: Repository slug
+        pr_id: PR ID
+        username: Reviewer username to remove
+    """
+    return _get_client().remove_pr_reviewer(project, repo, pr_id, username)  # pragma: no cover
 
 
 # --- File Tools (2 tools) ---


### PR DESCRIPTION
## Summary

- Add `bitbucket_pr_reviewer_list`, `bitbucket_pr_reviewer_add`, and `bitbucket_pr_reviewer_remove` tools
- Add optional `reviewers` parameter to `bitbucket_pr_create` for setting reviewers at PR creation time
- Cloud uses UUID-based reviewer identity; DC uses username-based identity with optimistic locking (version field)
- 19 new tests covering both Cloud and DC paths

## Changes

### Bitbucket MCP Server
- `src/bitbucket_mcp_server/client.py` — 3 new methods (`get_pr_reviewers`, `add_pr_reviewer`, `remove_pr_reviewer`) + `reviewers` param on `create_pr`
- `src/bitbucket_mcp_server/server.py` — 3 new `@mcp.tool()` registrations + updated `bitbucket_pr_create` signature
- `tests/unit/test_client.py` — 19 new tests: DC/Cloud for list/add/remove, empty reviewers, timeout, error, not-found user, create with reviewers

## Issue References

Closes #27

## Test Plan

- [x] Tests pass: `cd bitbucket-mcp-server && pytest` (335 passed)
- [x] Lint passes: `cd bitbucket-mcp-server && ruff check src/ tests/`
- [x] Type check passes: `cd bitbucket-mcp-server && mypy src/`
- [x] 100% coverage maintained (825 stmts, 0 missing)
- [x] Cloud reviewer format: `{"uuid": "..."}` in payloads
- [x] DC reviewer format: `{"user": {"name": "..."}}` with version field
- [x] Remove non-existent reviewer sends full list unchanged

---
Generated with [Claude Code](https://claude.ai/code)