### PR TITLE
chore(ci): add Semgrep and CodeQL security scanning (#30)

### DIFF
--- a/.claude/commands/submit-pr.md
+++ b/.claude/commands/submit-pr.md
@@ -73,6 +73,11 @@ cd <server> && pytest -v --tb=short 2>&1 | tail -80
 cd <server> && mypy src/ 2>&1 | tail -30
 ```
 
+**D — Semgrep SAST scan:**
+```bash
+semgrep --config .semgrep/ --config p/python --config p/owasp-top-ten <server>/src/ 2>&1 | tail -30
+```
+
 These are **blocking** — if any fail, abort.
 
 ### Step 4: Test Coverage for New Code
@@ -139,6 +144,7 @@ Verify all commits reference valid issues.
   Lint:           ✅ / ❌
   Tests:          ✅ / ❌ (per server)
   Type Check:     ✅ / ❌
+  Semgrep SAST:   ✅ / ❌
 
 🧪 Test Coverage
   Test Files:     ✅ / ❌
@@ -214,7 +220,7 @@ Run `/code-review` on the new PR. If issues found, offer to fix (max 2 rounds).
   🔗 PR:       #<N> — <title>
   🌐 URL:      <url>
   📎 Issues:   Closes #<N>
-  🧪 Checks:   ✅ lint, tests, types
+  🧪 Checks:   ✅ lint, tests, types, SAST
   🔒 Security: ✅
   🎯 Vision:   ✅
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    name: CodeQL Analysis
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,29 @@
+name: Semgrep SAST
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    name: Semgrep Security Scan
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Semgrep
+        uses: semgrep/semgrep-action@v1
+        with:
+          config: >-
+            p/python
+            p/owasp-top-ten
+            .semgrep/
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.semgrep/rules.yml
+++ b/.semgrep/rules.yml
@@ -1,0 +1,75 @@
+rules:
+  - id: no-verify-false
+    patterns:
+      - pattern-either:
+          - pattern: verify=False
+          - pattern: verify_ssl=False
+    message: >
+      TLS verification disabled. This violates OWASP ASVS V9 (Communication Security).
+      Never disable certificate verification in production code.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      owasp: V9 - Communication Security
+      cwe: "CWE-295: Improper Certificate Validation"
+
+  - id: no-eval-exec
+    pattern-either:
+      - pattern: eval(...)
+      - pattern: exec(...)
+    message: >
+      Dynamic code execution detected. This violates OWASP ASVS V5 (Input Validation).
+      Never use eval() or exec() with any input.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      owasp: V5 - Input Validation
+      cwe: "CWE-95: Improper Neutralization of Directives in Dynamically Evaluated Code"
+
+  - id: no-hardcoded-tokens
+    patterns:
+      - pattern-either:
+          - pattern: $VAR = "Bearer ..."
+          - pattern: $VAR = "Basic ..."
+          - pattern: $VAR = "token_..."
+          - pattern: $VAR = "sk-..."
+          - pattern: $VAR = "ghp_..."
+          - pattern: $VAR = "glpat-..."
+    message: >
+      Possible hardcoded credential detected. This violates OWASP ASVS V2 (Authentication).
+      All secrets must come from environment variables via pydantic-settings.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      owasp: V2 - Authentication
+      cwe: "CWE-798: Use of Hard-coded Credentials"
+
+  - id: no-shell-true
+    pattern-either:
+      - pattern: subprocess.call(..., shell=True, ...)
+      - pattern: subprocess.run(..., shell=True, ...)
+      - pattern: subprocess.Popen(..., shell=True, ...)
+    message: >
+      subprocess with shell=True detected. This violates OWASP ASVS V5 (Input Validation).
+      Use shell=False and pass arguments as a list.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      owasp: V5 - Input Validation
+      cwe: "CWE-78: Improper Neutralization of Special Elements used in an OS Command"
+
+  - id: no-pickle-loads
+    pattern: pickle.loads(...)
+    message: >
+      pickle.loads() on untrusted data is a deserialization vulnerability.
+      Use JSON or other safe serialization formats.
+    languages: [python]
+    severity: ERROR
+    metadata:
+      category: security
+      owasp: V5 - Input Validation
+      cwe: "CWE-502: Deserialization of Untrusted Data"


### PR DESCRIPTION
## Summary

- Add Semgrep SAST workflow with `p/python`, `p/owasp-top-ten`, and custom project rules
- Add CodeQL workflow with `security-extended` queries and weekly schedule
- Create 5 custom Semgrep rules enforcing project security patterns (no eval/exec, no verify=False, no hardcoded tokens, no shell=True, no pickle.loads)
- Update `/submit-pr` skill to include Semgrep SAST as a blocking pre-submission check

## Changes

### CI Workflows
- `.github/workflows/semgrep.yml` — Semgrep scan on push to main and PRs
- `.github/workflows/codeql.yml` — CodeQL Python analysis on push, PRs, and weekly schedule

### Custom Rules
- `.semgrep/rules.yml` — 5 rules covering OWASP ASVS forbidden patterns

### Skill Update
- `.claude/commands/submit-pr.md` — Added Semgrep SAST scan as Step 3D blocking check

## Issue References

Closes #30

## Test Plan

- [x] Semgrep rules parse without errors
- [x] Baseline scan: 0 findings across 36 files (162 rules)
- [x] YAML syntax validated for all workflow files
- [x] Security review passed (permissions minimal, no hardcoded secrets, safe triggers)

---
Generated with [Claude Code](https://claude.ai/code)