### PR TITLE
feat(confluence): add space pages listing tool (#28)

### DIFF
--- a/confluence-mcp-server/src/confluence_mcp_server/client.py
+++ b/confluence-mcp-server/src/confluence_mcp_server/client.py
@@ -323,6 +323,17 @@ class ConfluenceClient:
         except httpx.TimeoutException:
             raise ValueError("Timeout creating space")
 
+    def list_space_pages(self, space_key: str, limit: int = 25, start: int = 0) -> Dict[str, Any]:
+        url = f"{self._api_base}/content"
+        params = {"type": "page", "spaceKey": space_key, "limit": limit, "start": start}
+        try:
+            response = self._request("GET", url, params=params)
+            if response.status_code != 200:
+                self._handle_error(response)
+            return response.json()  # type: ignore[no-any-return]
+        except httpx.TimeoutException:
+            raise ValueError(f"Timeout listing pages in space {space_key}")
+
     # Comment operations
 
     def add_comment(self, page_id: str, body: str, representation: str = "storage") -> Dict[str, Any]:

--- a/confluence-mcp-server/src/confluence_mcp_server/server.py
+++ b/confluence-mcp-server/src/confluence_mcp_server/server.py
@@ -220,7 +220,7 @@ def confluence_search(
     return _get_client().search_content(query, space_key, content_type, limit, start)  # pragma: no cover
 
 
-# --- Space Tools (3 tools) ---
+# --- Space Tools (4 tools) ---
 
 
 @mcp.tool()
@@ -256,6 +256,20 @@ def confluence_space_create(
         description: Optional space description
     """
     return _get_client().create_space(key, name, description)  # pragma: no cover
+
+
+@mcp.tool()
+def confluence_space_pages(
+    space_key: str, limit: int = 25, start: int = 0
+) -> Dict[str, Any]:  # pragma: no cover
+    """List all pages in a Confluence space.
+
+    Args:
+        space_key: Space key (e.g., "DEV")
+        limit: Max results (default: 25)
+        start: Starting offset for pagination
+    """
+    return _get_client().list_space_pages(space_key, limit, start)  # pragma: no cover
 
 
 # --- Comment Tools (4 tools) ---


### PR DESCRIPTION
## Summary

- Add `list_space_pages()` client method for listing all pages in a Confluence space
- Add `confluence_space_pages` MCP tool with pagination support (limit, start)
- Mirrors existing `list_blogs` pattern — uses `GET /rest/api/content?type=page&spaceKey={key}`

## Changes

### Confluence
- `client.py` — added `list_space_pages(space_key, limit, start)` method
- `server.py` — added `confluence_space_pages` tool, updated Space Tools count to 4
- `tests/unit/test_client.py` — added `TestListSpacePages` (success, timeout, error)

## Issue References

Closes #28

## Test Plan

- [x] Tests pass: `cd confluence-mcp-server && pytest` (276 passed)
- [x] Lint passes: `cd confluence-mcp-server && ruff check src/ tests/`
- [x] 100% coverage maintained
- [x] Type check passes: `cd confluence-mcp-server && mypy src/`

---
Generated with [Claude Code](https://claude.ai/code)