### PR TITLE
feat(jira): add worklog support (add/list/delete)

### DIFF
--- a/jira-mcp-server/src/jira_mcp_server/client.py
+++ b/jira-mcp-server/src/jira_mcp_server/client.py
@@ -603,6 +603,48 @@ class JiraClient:
         except httpx.TimeoutException:
             raise ValueError(f"Timeout deleting attachment {attachment_id}")
 
+    # Worklog operations
+
+    def add_worklog(
+        self,
+        issue_key: str,
+        time_spent: str,
+        comment: str | None = None,
+        started: str | None = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/2/issue/{issue_key}/worklog"
+        data: Dict[str, Any] = {"timeSpent": time_spent}
+        if comment:
+            data["comment"] = comment
+        if started:
+            data["started"] = started
+        try:
+            response = self._request("POST", url, json=data)
+            if response.status_code not in (200, 201):
+                self._handle_error(response)
+            return response.json()  # type: ignore[no-any-return]
+        except httpx.TimeoutException:
+            raise ValueError(f"Timeout adding worklog to issue {issue_key}")
+
+    def list_worklogs(self, issue_key: str) -> Dict[str, Any]:
+        url = f"{self.base_url}/rest/api/2/issue/{issue_key}/worklog"
+        try:
+            response = self._request("GET", url)
+            if response.status_code != 200:
+                self._handle_error(response)
+            return response.json()  # type: ignore[no-any-return]
+        except httpx.TimeoutException:
+            raise ValueError(f"Timeout listing worklogs for issue {issue_key}")
+
+    def delete_worklog(self, issue_key: str, worklog_id: str) -> None:
+        url = f"{self.base_url}/rest/api/2/issue/{issue_key}/worklog/{worklog_id}"
+        try:
+            response = self._request("DELETE", url)
+            if response.status_code != 204:
+                self._handle_error(response)
+        except httpx.TimeoutException:
+            raise ValueError(f"Timeout deleting worklog {worklog_id} on issue {issue_key}")
+
     # Priority and status operations
 
     def list_priorities(self) -> List[Dict[str, Any]]:

--- a/jira-mcp-server/src/jira_mcp_server/server.py
+++ b/jira-mcp-server/src/jira_mcp_server/server.py
@@ -144,6 +144,18 @@ from jira_mcp_server.tools.workflow_tools import (
 from jira_mcp_server.tools.workflow_tools import (
     jira_workflow_transition as _impl_workflow_transition,
 )
+from jira_mcp_server.tools.worklog_tools import (
+    initialize_worklog_tools,
+)
+from jira_mcp_server.tools.worklog_tools import (
+    jira_worklog_add as _impl_worklog_add,
+)
+from jira_mcp_server.tools.worklog_tools import (
+    jira_worklog_delete as _impl_worklog_delete,
+)
+from jira_mcp_server.tools.worklog_tools import (
+    jira_worklog_list as _impl_worklog_list,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -738,6 +750,50 @@ def jira_attachment_delete(attachment_id: str) -> Dict[str, Any]:
     return _impl_attachment_delete(attachment_id=attachment_id)  # pragma: no cover
 
 
+# --- Worklog Tools ---
+
+
+@mcp.tool()
+def jira_worklog_add(
+    issue_key: str,
+    time_spent: str,
+    comment: str | None = None,
+    started: str | None = None,
+) -> Dict[str, Any]:
+    """Add a worklog entry to an issue for time tracking.
+
+    Args:
+        issue_key: Issue key (e.g., "PROJ-123")
+        time_spent: Time spent in Jira duration format (e.g., "2h", "30m", "1d", "1h 30m")
+        comment: Optional worklog comment
+        started: Optional start time in ISO format (defaults to now)
+    """
+    return _impl_worklog_add(  # pragma: no cover
+        issue_key=issue_key, time_spent=time_spent, comment=comment, started=started
+    )
+
+
+@mcp.tool()
+def jira_worklog_list(issue_key: str) -> Dict[str, Any]:
+    """List all worklog entries for an issue.
+
+    Args:
+        issue_key: Issue key (e.g., "PROJ-123")
+    """
+    return _impl_worklog_list(issue_key=issue_key)  # pragma: no cover
+
+
+@mcp.tool()
+def jira_worklog_delete(issue_key: str, worklog_id: str) -> Dict[str, Any]:
+    """Delete a worklog entry from an issue.
+
+    Args:
+        issue_key: Issue key (e.g., "PROJ-123")
+        worklog_id: Worklog entry ID to delete
+    """
+    return _impl_worklog_delete(issue_key=issue_key, worklog_id=worklog_id)  # pragma: no cover
+
+
 # --- Priority & Status Tools ---
 
 
@@ -778,6 +834,7 @@ def main() -> None:
         initialize_sprint_tools(client, config)
         initialize_user_tools(client, config)
         initialize_attachment_tools(client)
+        initialize_worklog_tools(client, config)
 
         from importlib.metadata import version as pkg_version
 

--- a/jira-mcp-server/src/jira_mcp_server/tools/worklog_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/worklog_tools.py
@@ -1,0 +1,68 @@
+"""MCP tools for issue worklogs (time tracking)."""
+
+from typing import Any, Dict, Optional
+
+from jira_mcp_server.client import JiraClient
+from jira_mcp_server.config import JiraConfig
+
+_client: Optional[JiraClient] = None
+_config: Optional[JiraConfig] = None
+
+
+def initialize_worklog_tools(client: JiraClient, config: JiraConfig) -> None:
+    global _client, _config
+    _client = client
+    _config = config
+
+
+def jira_worklog_add(
+    issue_key: str,
+    time_spent: str,
+    comment: Optional[str] = None,
+    started: Optional[str] = None,
+) -> Dict[str, Any]:
+    if not _client:
+        raise RuntimeError("Worklog tools not initialized")
+    if not issue_key or not issue_key.strip():
+        raise ValueError("Issue key cannot be empty")
+    if not time_spent or not time_spent.strip():
+        raise ValueError("Time spent cannot be empty")
+    try:
+        return _client.add_worklog(
+            issue_key=issue_key,
+            time_spent=time_spent,
+            comment=comment,
+            started=started,
+        )
+    except Exception as e:
+        raise ValueError(f"Add worklog failed: {str(e)}")
+
+
+def jira_worklog_list(issue_key: str) -> Dict[str, Any]:
+    if not _client:
+        raise RuntimeError("Worklog tools not initialized")
+    if not issue_key or not issue_key.strip():
+        raise ValueError("Issue key cannot be empty")
+    try:
+        return _client.list_worklogs(issue_key=issue_key)
+    except Exception as e:
+        raise ValueError(f"List worklogs failed: {str(e)}")
+
+
+def jira_worklog_delete(issue_key: str, worklog_id: str) -> Dict[str, Any]:
+    if not _client:
+        raise RuntimeError("Worklog tools not initialized")
+    if not issue_key or not issue_key.strip():
+        raise ValueError("Issue key cannot be empty")
+    if not worklog_id or not worklog_id.strip():
+        raise ValueError("Worklog ID cannot be empty")
+    try:
+        _client.delete_worklog(issue_key=issue_key, worklog_id=worklog_id)
+        return {
+            "success": True,
+            "message": f"Worklog {worklog_id} deleted successfully",
+            "issue_key": issue_key,
+            "worklog_id": worklog_id,
+        }
+    except Exception as e:
+        raise ValueError(f"Delete worklog failed: {str(e)}")


### PR DESCRIPTION
## Summary

- Add 3 worklog MCP tools: `jira_worklog_add`, `jira_worklog_list`, `jira_worklog_delete`
- Implement client methods for POST/GET/DELETE on `/rest/api/2/issue/{key}/worklog`
- Full input validation and error handling following existing patterns
- 26 new tests across client and tool layers

## Changes

### jira-mcp-server
- `src/jira_mcp_server/client.py` — 3 new methods: `add_worklog`, `list_worklogs`, `delete_worklog`
- `src/jira_mcp_server/tools/worklog_tools.py` — new tool module with validation
- `src/jira_mcp_server/server.py` — 3 `@mcp.tool()` wrappers + `initialize_worklog_tools` in main()
- `tests/unit/test_client.py` — 14 new client tests
- `tests/unit/test_tools.py` — 12 new tool tests + 1 init test

## Issue References

Closes #25

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (716 passed)
- [x] Lint passes: `cd jira-mcp-server && ruff check src/ tests/`
- [x] 100% coverage maintained on all modules
- [x] Success, error, timeout, and validation paths tested

---
Generated with [Claude Code](https://claude.ai/code)