### PR TITLE
feat: add attachment content download for Jira and Confluence (#26)

### DIFF
--- a/confluence-mcp-server/src/confluence_mcp_server/server.py
+++ b/confluence-mcp-server/src/confluence_mcp_server/server.py
@@ -460,6 +460,25 @@ def confluence_attachment_delete(attachment_id: str) -> Dict[str, Any]:  # pragm
     return {"success": True, "message": f"Attachment {attachment_id} deleted"}  # pragma: no cover
 
 
+@mcp.tool()
+def confluence_attachment_download(  # pragma: no cover
+    attachment_id: str, max_size: int | None = None,
+) -> Dict[str, Any]:
+    """Download attachment content.
+
+    Returns text content directly for text files, or base64-encoded content for binary files.
+    Default max size is 10MB.
+
+    Args:
+        attachment_id: Attachment ID
+        max_size: Optional max size in bytes (default 10MB)
+    """
+    kwargs: Dict[str, Any] = {}  # pragma: no cover
+    if max_size is not None:  # pragma: no cover
+        kwargs["max_size"] = max_size  # pragma: no cover
+    return _get_client().download_attachment(attachment_id, **kwargs)  # pragma: no cover
+
+
 # --- Label Tools (3 tools) ---
 
 

--- a/jira-mcp-server/src/jira_mcp_server/server.py
+++ b/jira-mcp-server/src/jira_mcp_server/server.py
@@ -18,6 +18,9 @@ from jira_mcp_server.tools.attachment_tools import (
     jira_attachment_delete as _impl_attachment_delete,
 )
 from jira_mcp_server.tools.attachment_tools import (
+    jira_attachment_download as _impl_attachment_download,
+)
+from jira_mcp_server.tools.attachment_tools import (
     jira_attachment_get as _impl_attachment_get,
 )
 from jira_mcp_server.tools.board_tools import (
@@ -748,6 +751,20 @@ def jira_attachment_delete(attachment_id: str) -> Dict[str, Any]:
         attachment_id: Attachment ID
     """
     return _impl_attachment_delete(attachment_id=attachment_id)  # pragma: no cover
+
+
+@mcp.tool()
+def jira_attachment_download(attachment_id: str, max_size: int | None = None) -> Dict[str, Any]:
+    """Download attachment content.
+
+    Returns text content directly for text files, or base64-encoded content for binary files.
+    Default max size is 10MB.
+
+    Args:
+        attachment_id: Attachment ID
+        max_size: Optional max size in bytes (default 10MB)
+    """
+    return _impl_attachment_download(attachment_id=attachment_id, max_size=max_size)  # pragma: no cover
 
 
 # --- Worklog Tools ---

--- a/jira-mcp-server/src/jira_mcp_server/tools/attachment_tools.py
+++ b/jira-mcp-server/src/jira_mcp_server/tools/attachment_tools.py
@@ -46,3 +46,17 @@ def jira_attachment_delete(attachment_id: str) -> Dict[str, Any]:
         return {"success": True, "message": f"Attachment {attachment_id} deleted successfully"}
     except Exception as e:
         raise ValueError(f"Delete attachment failed: {str(e)}")
+
+
+def jira_attachment_download(attachment_id: str, max_size: int | None = None) -> Dict[str, Any]:
+    if not _client:
+        raise RuntimeError("Attachment tools not initialized")
+    if not attachment_id or not attachment_id.strip():
+        raise ValueError("Attachment ID cannot be empty")
+    try:
+        kwargs: Dict[str, Any] = {}
+        if max_size is not None:
+            kwargs["max_size"] = max_size
+        return _client.download_attachment(attachment_id, **kwargs)
+    except Exception as e:
+        raise ValueError(f"Download attachment failed: {str(e)}")


### PR DESCRIPTION
## Summary

- Add `download_attachment` client method to both Jira and Confluence servers
- Add `jira_attachment_download` and `confluence_attachment_download` MCP tools
- Text files (text/*, JSON, XML, YAML, JS) returned as raw text; binary files as base64
- 10MB default size limit with configurable `max_size` parameter
- Size validated both from metadata and actual response content

## Changes

### Jira MCP Server
- `client.py` — add `download_attachment()` method (2-step: metadata fetch then content download)
- `tools/attachment_tools.py` — add `jira_attachment_download()` tool function
- `server.py` — add `@mcp.tool()` wrapper and import alias

### Confluence MCP Server
- `client.py` — add `download_attachment()` method (constructs URL from `base_url` + `_links.download`)
- `server.py` — add `confluence_attachment_download()` tool directly

### Tests
- 11 new Jira client tests + 5 tool tests
- 11 new Confluence client tests
- 100% coverage maintained on both servers

## Issue References

Closes #26

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (731 passed)
- [x] Tests pass: `cd confluence-mcp-server && pytest` (346 passed)
- [x] Lint passes: `ruff check src/ tests/` (both servers)
- [x] 100% coverage maintained
- [x] Text file download returns `encoding: "text"`
- [x] Binary file download returns `encoding: "base64"`
- [x] Oversized files rejected from metadata and actual content
- [x] Missing download URL raises clear error
- [x] Timeout and error responses handled

---
Generated with [Claude Code](https://claude.ai/code)