### PR TITLE
feat(jira): add subtask creation helper (#29)

### DIFF
--- a/jira-mcp-server/src/jira_mcp_server/server.py
+++ b/jira-mcp-server/src/jira_mcp_server/server.py
@@ -87,6 +87,9 @@ from jira_mcp_server.tools.issue_tools import (
 from jira_mcp_server.tools.issue_tools import (
     jira_issue_update as _impl_issue_update,
 )
+from jira_mcp_server.tools.issue_tools import (
+    jira_subtask_create as _impl_subtask_create,
+)
 from jira_mcp_server.tools.project_tools import (
     initialize_project_tools,
 )
@@ -232,6 +235,40 @@ def jira_issue_create(
         labels=labels or [],
         due_date=due_date,
         **kwargs,
+    )
+
+
+@mcp.tool()
+def jira_subtask_create(
+    parent_key: str,
+    summary: str,
+    description: str = "",
+    priority: str | None = None,
+    assignee: str | None = None,
+    labels: list[str] | None = None,
+    due_date: str | None = None,
+) -> Dict[str, Any]:
+    """Create a subtask under an existing issue.
+
+    Auto-detects the project's subtask issue type. Falls back to "Sub-task" if not found.
+
+    Args:
+        parent_key: Parent issue key (e.g., "PROJ-123")
+        summary: Subtask title/summary
+        description: Detailed description
+        priority: Issue priority
+        assignee: Username or user ID to assign
+        labels: List of labels
+        due_date: Due date in ISO format (YYYY-MM-DD)
+    """
+    return _impl_subtask_create(  # pragma: no cover
+        parent_key=parent_key,
+        summary=summary,
+        description=description,
+        priority=priority,
+        assignee=assignee,
+        labels=labels or [],
+        due_date=due_date,
     )
 
 


### PR DESCRIPTION
## Summary

- Add `jira_subtask_create` MCP tool for creating subtasks under existing issues
- Auto-detects the project's subtask issue type via `get_project()` API
- Falls back to "Sub-task" if no subtask type found in the project
- Supports optional fields: description, priority, assignee, labels, due_date

## Changes

### Jira MCP Server
- `tools/issue_tools.py` — add `jira_subtask_create()` function with auto-detection of subtask issue type, parent key validation, and schema validation
- `server.py` — add import alias + `@mcp.tool()` wrapper with typed parameters
- `tests/unit/test_tools.py` — add `TestSubtaskCreate` class with 12 tests

## Issue References

Closes #29

## Test Plan

- [x] Tests pass: `cd jira-mcp-server && pytest` (743 passed)
- [x] Lint passes: `ruff check src/ tests/`
- [x] Type check: `mypy src/` — no issues
- [x] Semgrep SAST: 0 findings
- [x] 100% coverage maintained
- [x] Auto-detects subtask type from project issue types
- [x] Falls back to "Sub-task" when no subtask type found
- [x] Validates parent key format (must contain hyphen)
- [x] Handles all error paths: project not found, schema failure, validation failure, API error

---
Generated with [Claude Code](https://claude.ai/code)